### PR TITLE
feat: BaseInput 컴포넌트 웹 접근성 추가

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,3 +1,6 @@
+let uid = 0;
+const getUid = () => uid++;
+
 const numToPx = (num: number) => {
   if (num !== 0) {
     return `${num}px`;
@@ -6,5 +9,6 @@ const numToPx = (num: number) => {
 };
 
 export {
+  getUid,
   numToPx,
 };

--- a/src/components/baseInput/BaseInput.vue
+++ b/src/components/baseInput/BaseInput.vue
@@ -1,28 +1,11 @@
-<template>
-  <input
-    type="text"
-    :value="modelValue"
-    :aria-label="props.label"
-    :autocomplete="props.autocomplete"
-    :disabled="props.disabled"
-    :placeholder="props.placeholder"
-    :readonly="props.readonly"
-    :required="props.required"
-    class="base-input"
-    @input="handleInput"
-    @focus="handleFocus"
-    @blur="handleBlur"
-    @change="onChange"
-  >
-</template>
-
 <script setup lang="ts">
+import { getUid } from '@/common/utils';
 import { useInput } from './uses';
 
 export interface Props {
   nativeType?: string;
   modelValue: string | number;
-  label: string;
+  label?: string;
   autocomplete?: string;
   disabled?: boolean;
   placeholder?: string;
@@ -39,6 +22,7 @@ interface Emit {
 }
 const props = withDefaults(defineProps<Props>(), {
   nativeType: 'text',
+  label: '',
   autocomplete: 'off',
   disabled: false,
   placeholder: '',
@@ -48,6 +32,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const emit = defineEmits<Emit>();
 
+const uuid = getUid();
+
 const {
   handleInput,
   handleFocus,
@@ -56,26 +42,71 @@ const {
 } = useInput(props, emit);
 </script>
 
+<template>
+  <div class="base-input">
+    <label
+      v-if="props.label"
+      class="base-input__label"
+      :for="uuid"
+    >
+      {{ label }}
+    </label>
+    <input
+      :id="uuid"
+      type="text"
+      :value="modelValue"
+      :aria-label="props.label"
+      :autocomplete="props.autocomplete"
+      :disabled="props.disabled"
+      :placeholder="props.placeholder"
+      :readonly="props.readonly"
+      :required="props.required"
+      class="base-input__input"
+      @input="handleInput"
+      @focus="handleFocus"
+      @blur="handleBlur"
+      @change="onChange"
+    >
+  </div>
+</template>
+
 <style lang="scss">
 .base-input {
-  width: 200px;
-  height: 40px;
-  padding: 8px 8px 8px 16px;
-  color: rgba(228, 230, 244, 0.68);
-  font-size: 16px;
-  border-radius: 10px;
-  border: 1px solid #42475D;
-  box-sizing: border-box;
-  &::placeholder {
-    color: rgba(228, 230, 244, 0.38);
+  display: flex;
+  gap: 8px;
+
+  .base-input__label {
+    display: inline-flex;
+    font-size: 16px;
+    color: rgba(228, 230, 244, 0.68);
+    align-self: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
-  &:hover {
-    outline: none !important;
-    border: 1px solid #494C61;
-  }
-  &:focus {
-    outline: none !important;
-    border: 2px solid #7367F0;
+  .base-input__input {
+    width: 100%;
+    height: 40px;
+    padding: 8px 8px 8px 16px;
+    background-color: transparent;
+    color: rgba(228, 230, 244, 0.68);
+    font-size: 16px;
+    border-radius: 10px;
+    border: 1px solid #42475D;
+    box-sizing: border-box;
+
+    &::placeholder {
+      color: rgba(228, 230, 244, 0.38);
+    }
+
+    &:hover {
+      outline: none !important;
+      border: 1px solid #494C61;
+    }
+
+    &:focus {
+      outline: none !important;
+      border: 2px solid #7367F0;
+    }
   }
 }
 </style>

--- a/src/components/baseInput/uses.ts
+++ b/src/components/baseInput/uses.ts
@@ -1,7 +1,7 @@
 export interface Props {
   nativeType: string;
   modelValue: string | number;
-  label: string;
+  label?: string;
   autocomplete?: string;
   disabled?: boolean;
   placeholder?: string;


### PR DESCRIPTION
## 작업 내용
- label 바인딩 props값을 추가하면 BaseInput에 라벨명이 생성
- a11y에 맞게 `<label>` 추가

## 공유 내용
- `<label>`의 for 속성값과 `<input>`의 id 속성값 연결
- uuid 공통함수 추가하여 BaseInput에 추가

## 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|![image](https://user-images.githubusercontent.com/10824092/215335806-b3a50020-f791-447f-9b77-2ffaa66244f4.png)|

## 관련 이슈
Close #2
